### PR TITLE
Catch errors thrown when trying to set on local storage

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -85,7 +85,7 @@ describe('Channel', () => {
   });
 
   it('should emit even when it fails to set the value on local storage', done => {
-    spyOn( localStorage, 'setItem' ).and.throwError('example error');
+    spyOn(localStorage, 'setItem').and.throwError('example error');
     const action = (_key: string, ch: Channel<number>) => {
       ch.next(1);
       ch.next(2);

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -84,6 +84,18 @@ describe('Channel', () => {
     takeAndTest(2, action, assert, done);
   });
 
+  it('should emit even when it fails to set the value on local storage', done => {
+    spyOn( localStorage, 'setItem' ).and.throwError('example error');
+    const action = (_key: string, ch: Channel<number>) => {
+      ch.next(1);
+      ch.next(2);
+    };
+    const assert = (val: any) => {
+      expect(val).toEqual([1, 2]);
+    };
+    takeAndTest(2, action, assert, done);
+  });
+
   describe('next', () => {
     it('should return undefined', () => {
       const { ch } = prepare();

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export class Channel<T> extends Subject<T> {
     try {
       localStorage.setItem(this.key, value);
     } catch (err) {
-      console.error(err.message);
+      console.error(err);
     }
     this.emit(data);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,11 @@ export class Channel<T> extends Subject<T> {
   public next(data: T): void {
     const event = { id: this.nextId(), data };
     const value = JSON.stringify(event);
-    localStorage.setItem(this.key, value);
+    try {
+      localStorage.setItem(this.key, value);
+    } catch (err) {
+      console.error(err.message);
+    }
     this.emit(data);
   }
 


### PR DESCRIPTION
With this change, the current browser tab will continue to work. It'll log an error on the browser console. Changes will not get sent to other browser tabs because it fails to set it on local storage.